### PR TITLE
timeformatに一桁の場合を追加

### DIFF
--- a/BigTimer/Model/TimeFormat.swift
+++ b/BigTimer/Model/TimeFormat.swift
@@ -8,7 +8,9 @@
 import Foundation
 
 enum TimeFormat {
-    case hr
-    case min
+    case hr1
+    case hr2
+    case min1
+    case min2
     case sec
 }

--- a/BigTimer/Model/TimeModel.swift
+++ b/BigTimer/Model/TimeModel.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 class TimerModel: ObservableObject{
-    var displayedTimeFormat: TimeFormat = .min
+    var displayedTimeFormat: TimeFormat = .min1
     var setTime: Double = 0
     var timeLeft: Double = 0
     var timerStatus: TimerStatus = .ready

--- a/BigTimer/View/Components/TimeTextView.swift
+++ b/BigTimer/View/Components/TimeTextView.swift
@@ -14,8 +14,12 @@ struct TimeTextView: View {
         GeometryReader{geometry in
             VStack{
                 Spacer()
-                Text(self.timerViewModel.timeLeftStr)
-                    .font(.custom("DSEG7ClassicMini-Bold", size: geometry.size.width / CGFloat(timerViewModel.timeLeftStrNum)))
+                HStack{
+                    Spacer()
+                    Text(self.timerViewModel.timeLeftStr)
+                        .font(.custom("DSEG7ClassicMini-Bold", size: timerViewModel.calcTimeSize(height: geometry.size.height, width: geometry.size.width)))
+                    Spacer()
+                }
                 Spacer()
             }
         }

--- a/BigTimer/ViewModel/TimerViewModel.swift
+++ b/BigTimer/ViewModel/TimerViewModel.swift
@@ -48,16 +48,16 @@ class TimerViewModel: ObservableObject{
         switch timerModel.displayedTimeFormat {
         case .hr2:
             self.timeLeftStr = String(format: "%02d:%02d:%02d", hr, min, sec)
-            self.timeLeftStrNum = 5.4
+            self.timeLeftStrNum = 5.5
         case .hr1:
             self.timeLeftStr = String(format: "%01d:%02d:%02d", hr, min, sec)
-            self.timeLeftStrNum = 4.5
+            self.timeLeftStrNum = 4.6
         case .min2:
             self.timeLeftStr = String(format: "%02d:%02d", min, sec)
-            self.timeLeftStrNum = 3.5
+            self.timeLeftStrNum = 3.6
         case .min1:
             self.timeLeftStr = String(format: "%01d:%02d", min, sec)
-            self.timeLeftStrNum = 2.7
+            self.timeLeftStrNum = 2.8
         case .sec:
             self.timeLeftStr = String(format: "%02d", sec)
             self.timeLeftStrNum = 1.8

--- a/BigTimer/ViewModel/TimerViewModel.swift
+++ b/BigTimer/ViewModel/TimerViewModel.swift
@@ -64,6 +64,15 @@ class TimerViewModel: ObservableObject{
         }
     }
     
+    func calcTimeSize(height: CGFloat, width: CGFloat) -> CGFloat{
+        let width_size = width / CGFloat(self.timeLeftStrNum)
+        if width_size < height{
+            return width_size
+        } else{
+            return height
+        }
+    }
+    
     func run(){
         guard self.timerModel.timerStatus == .running else { return }
         

--- a/BigTimer/ViewModel/TimerViewModel.swift
+++ b/BigTimer/ViewModel/TimerViewModel.swift
@@ -29,10 +29,14 @@ class TimerViewModel: ObservableObject{
         
         if timerModel.timeLeft < Double(minSec) {
             timerModel.displayedTimeFormat = .sec
+        } else if timerModel.timeLeft < Double(minSec * 10) {
+            timerModel.displayedTimeFormat = .min1
         } else if timerModel.timeLeft < Double(hourSec) {
-            timerModel.displayedTimeFormat = .min
+            timerModel.displayedTimeFormat = .min2
+        } else if timerModel.timeLeft < Double(hourSec * 10) {
+            timerModel.displayedTimeFormat = .hr1
         } else {
-            timerModel.displayedTimeFormat = .hr
+            timerModel.displayedTimeFormat = .hr2
         }
     }
     
@@ -42,12 +46,18 @@ class TimerViewModel: ObservableObject{
         let sec = Int(timerModel.timeLeft) % hourSec % minSec
         
         switch timerModel.displayedTimeFormat {
-        case .hr:
+        case .hr2:
             self.timeLeftStr = String(format: "%02d:%02d:%02d", hr, min, sec)
             self.timeLeftStrNum = 5.4
-        case .min:
+        case .hr1:
+            self.timeLeftStr = String(format: "%01d:%02d:%02d", hr, min, sec)
+            self.timeLeftStrNum = 4.5
+        case .min2:
             self.timeLeftStr = String(format: "%02d:%02d", min, sec)
             self.timeLeftStrNum = 3.5
+        case .min1:
+            self.timeLeftStr = String(format: "%01d:%02d", min, sec)
+            self.timeLeftStrNum = 2.7
         case .sec:
             self.timeLeftStr = String(format: "%02d", sec)
             self.timeLeftStrNum = 1.8


### PR DESCRIPTION
時間・分を表示する時に一桁だった場合には0埋めして二桁にせずに、一桁のままで表示するように変更。